### PR TITLE
Use ResettingNonRateCounter to count errors so that the metric will be

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 0.1.4 / 2017-12-01 Upgrade haystack-metrics to 0.2.9, use new ResettingNonRateCounter
+This is so that the metric produced when an error occurs will be a count, not a rate.
+
 ## 0.1.3 / 2017-12-01 Upgrade haystack-metrics to 0.2.7
 This resulted in the renaming of variables and methods to refer to "host" instead of "address"
 and is done to have a consistent name across all of Haystack.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-logback-metrics-appender</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.1.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
@@ -55,7 +55,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <haystack-metrics-version>0.2.7</haystack-metrics-version>
+        <haystack-metrics-version>0.2.9</haystack-metrics-version>
         <java.version>1.8</java.version>
         <jacoco-maven-plugin-version>0.7.9</jacoco-maven-plugin-version>
         <jacoco-percentage>1.0</jacoco-percentage>

--- a/src/main/java/com/expedia/www/haystack/metrics/appenders/logback/EmitToGraphiteLogbackAppender.java
+++ b/src/main/java/com/expedia/www/haystack/metrics/appenders/logback/EmitToGraphiteLogbackAppender.java
@@ -130,7 +130,7 @@ public class EmitToGraphiteLogbackAppender extends AppenderBase<ILoggingEvent> {
     static class Factory {
 
         Counter createCounter(String application, String className, String counterName) {
-            return metricObjects.createAndRegisterCounter(SUBSYSTEM, application, className, counterName);
+            return metricObjects.createAndRegisterResettingNonRateCounter(SUBSYSTEM, application, className, counterName);
         }
 
         MetricPublishing createMetricPublishing() {

--- a/src/test/java/com/expedia/www/haystack/metrics/appenders/logback/EmitToGraphiteLogbackAppenderTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/appenders/logback/EmitToGraphiteLogbackAppenderTest.java
@@ -116,13 +116,13 @@ public class EmitToGraphiteLogbackAppenderTest {
 
     @Test
     public void testFactoryCreateCounter() {
-        when(mockMetricObjects.createAndRegisterCounter(anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(mockCounter);
+        when(mockMetricObjects.createAndRegisterResettingNonRateCounter(
+                anyString(), anyString(), anyString(), anyString())).thenReturn(mockCounter);
 
         final Counter counter = realFactory.createCounter(APPLICATION, FULLY_QUALIFIED_CLASS_NAME, COUNTER_NAME);
 
         assertSame(mockCounter, counter);
-        verify(mockMetricObjects).createAndRegisterCounter(
+        verify(mockMetricObjects).createAndRegisterResettingNonRateCounter(
                 SUBSYSTEM, APPLICATION, FULLY_QUALIFIED_CLASS_NAME, COUNTER_NAME);
     }
 


### PR DESCRIPTION
a count, not a rate.