### PR TITLE
Emit a "heartbeat metric" every minute (metric value always 0,

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,6 +1,11 @@
 # Release Notes
 
-## 0.1.6 / 2017-12-15 Separate polling thread per appender; emit start up metric; call close() when shutting down
+## 0.1.7 / 2017-12-20 Emit an ERROR metric, with a count of 0, every minute
+The writing of a metric to show that the appender is working now occurs in a background thread every minute;
+the value of the metric thus emitted will be 0. When an error occurs, the value of the metric will be greater than 0,
+and the tags of the metric will be different than what was emitted by the background thread.
+
+## 0.1.6 / 2017-12-18 Separate polling thread per appender; emit start up metric; call close() when shutting down
 As part of an effort to be sure that the connection to the metrics database is closed when the appender is
 no longer being used, each appender will have its own polling thread, and close() will be called appropriately.
 This version also includes the writing of a start up metric to show that the appender is working, since it

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-logback-metrics-appender</artifactId>
-    <version>0.1.6-SNAPSHOT</version>
+    <version>0.1.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/main/java/com/expedia/www/haystack/metrics/appenders/logback/StartUpMetric.java
+++ b/src/main/java/com/expedia/www/haystack/metrics/appenders/logback/StartUpMetric.java
@@ -17,16 +17,37 @@
 package com.expedia.www.haystack.metrics.appenders.logback;
 
 import ch.qos.logback.classic.Level;
+import com.expedia.www.haystack.metrics.MetricObjects;
 import com.netflix.servo.monitor.Counter;
 
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+
 class StartUpMetric {
-    static final int METRIC_VALUE = -1;
+    private static final int METRIC_VALUE = 0;
+    private static final long INITIAL_DELAY_MILLIS = 0L;
+    private static final int INTERVAL_MINUTES = 1;
+
+    StartUpMetric(Timer timer, EmitToGraphiteLogbackAppender.Factory factory, MetricObjects metricObjects) {
+        timer.scheduleAtFixedRate(
+                new TimerTask() {
+                    public void run() {
+                        emit(metricObjects, factory);
+                    }
+                },
+                INITIAL_DELAY_MILLIS,
+                TimeUnit.MINUTES.toMillis(INTERVAL_MINUTES));
+    }
+
     static final String LINE_NUMBER_OF_EMIT_START_UP_METRIC_METHOD = Integer.toString(
-            new Throwable().getStackTrace()[0].getLineNumber() + 2);
-    void emit(EmitToGraphiteLogbackAppender.Factory factory) {
+            new Throwable().getStackTrace()[0].getLineNumber() + 3);
+
+    void emit(MetricObjects metricObjects, EmitToGraphiteLogbackAppender.Factory factory) {
         final String fullyQualifiedClassName = EmitToGraphiteLogbackAppender.changePeriodsToDashes(
                 StartUpMetric.class.getName());
-        final Counter counter = factory.createCounter(
+        final Counter counter = factory.createCounter(metricObjects,
                 fullyQualifiedClassName, LINE_NUMBER_OF_EMIT_START_UP_METRIC_METHOD, Level.ERROR.toString());
         counter.increment(METRIC_VALUE);
-    }}
+    }
+}


### PR DESCRIPTION
metric tags point to the emit() method of the StartUpMetric class).
This change involved having fewer static dependencies to make the tests
work (and removing static dependencies is a Good Thing). Also changed
EmitToGraphiteLogbackAppender.ERROR_COUNTERS to have a unique key
(previously the key was StackTraceElement.hashCode() so there was a
small but non-zero changes of key collisions in the Map).