### PR TITLE
Add the subsystem name to the fully qualified class name of the metric,

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ style number (milliseconds since January 1, 1970, midnight GMT). The format of t
 is used in the data.influxdb.templates array [here](https://github.com/ExpediaDotCom/haystack/blob/master/deployment/k8s/addons/1.6/monitoring/influxdb.yaml#L91)
 and is of the following format:
 
-```haystack.errors.<fully-qualified-class-name>.<server>.<lineNumber>.<ERROR_TYPE>_<suffix>```
+```haystack.errors.<subsystem-fully-qualified-class-name>.<server>.<lineNumber>.<ERROR_TYPE>_<suffix>```
 
 where 
-* `<fully-qualified-class-name>` is something like `com-foo-MyClass` (`com.foo` is the package, `MyClass` is the name
-of the class, and all the periods have been replaced by hyphens).
+* `<subsystem-fully-qualified-class-name>` is the name of the subsystem (like `pipes`, `collector`, etc.), followed by
+a dash and then something like `com-foo-MyClass` (`com.foo` is the package, `MyClass` is the name of the class, and all 
+the periods in the package have been replaced by hyphens).
 * `<server>` is the name of the server where the error occurred.
 * `<lineNumber>` is the line number in MyClass.java or MyClass.scala where the call to log the error was made.
 * `ERROR_TYPE` is either `ERROR` or `FATAL`.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.1.9 / 2018-01-05 Include subsystem in fqName of error metric
+so that the heartbeat metric is different for each subsystem. This permits writing a dashboard with two metrics (the 
+first based on the fqName tag matching the fully qualified name in the heartbeat metric and the second based on the
+fqName tag NOT matching the fully qualified name in the heartbeat metric) before any non-heartbeat errors have occurred.
+
 ## 0.1.8 / 2018-01-05 Shutdown heartbeat metric when appender stops
 
 ## 0.1.7 / 2017-12-20 Emit an ERROR metric, with a count of 0, every minute

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-logback-metrics-appender</artifactId>
-    <version>0.1.8-SNAPSHOT</version>
+    <version>0.1.9-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>

--- a/src/test/java/com/expedia/www/haystack/metrics/appenders/logback/EmitToGraphiteLogbackAppenderTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/appenders/logback/EmitToGraphiteLogbackAppenderTest.java
@@ -42,13 +42,16 @@ import static ch.qos.logback.classic.Level.INFO;
 import static ch.qos.logback.classic.Level.TRACE;
 import static ch.qos.logback.classic.Level.WARN;
 import static com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender.ERRORS_COUNTERS;
-import static com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender.SUBSYSTEM;
+import static com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender.ERRORS_SUBSYSTEM;
+import static com.expedia.www.haystack.metrics.appenders.logback.StartUpMetricTest.LINE_NUMBER_OF_EMIT_METHOD_IN_START_UP_METRIC_CLASS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -57,6 +60,7 @@ import static org.mockito.Mockito.when;
 public class EmitToGraphiteLogbackAppenderTest {
     private static final Random RANDOM = new Random();
     private static final String APPLICATION = RANDOM.nextLong() + "APPLICATION";
+    private static final String SUBSYSTEM = RANDOM.nextLong() + "SUBSYSTEM";
     private static final String HOST = RANDOM.nextLong() + "HOST";
     private static final String METHOD_NAME = RANDOM.nextLong() + "METHOD_NAME";
     private static final String FILE_NAME = RANDOM.nextLong() + "FILE_NAME";
@@ -64,9 +68,12 @@ public class EmitToGraphiteLogbackAppenderTest {
     private static final int POLL_INTERVAL_SECONDS = RANDOM.nextInt(Byte.MAX_VALUE);
     private static final int QUEUE_SIZE = RANDOM.nextInt(Byte.MAX_VALUE);
     private static final int LINE_NUMBER = RANDOM.nextInt(Integer.MAX_VALUE);
+    private static final String S_LINE_NUMBER = Integer.toString(LINE_NUMBER);
     private static final boolean SEND_AS_RATE = RANDOM.nextBoolean();
-    private static final Class<EmitToGraphiteLogbackAppenderTest> CLASS = EmitToGraphiteLogbackAppenderTest.class;
-    private static final String FULLY_QUALIFIED_CLASS_NAME = CLASS.getName().replace('.', '-');
+    private static final Class<StartUpMetric> START_UP_METRIC_CLASS = StartUpMetric.class;
+    private static final String START_UP_METRIC_FULLY_QUALIFIED_CLASS_NAME = START_UP_METRIC_CLASS.getName().replace('.', '-');
+    private static final Class<EmitToGraphiteLogbackAppenderTest> TEST_CLASS = EmitToGraphiteLogbackAppenderTest.class;
+    private static final String TEST_CLASS_NAME = TEST_CLASS.getName().replace('.', '-');
     private static final String COUNTER_NAME = ERROR.toString();
     private static final GraphiteConfig GRAPHITE_CONFIG = new GraphiteConfigImpl(
             HOST, PORT, POLL_INTERVAL_SECONDS, QUEUE_SIZE, SEND_AS_RATE);
@@ -98,10 +105,10 @@ public class EmitToGraphiteLogbackAppenderTest {
     @Before
     public void setUp() {
         factory = new Factory();
-        when(mockFactory.createStartUpMetric(any(MetricObjects.class), any(Timer.class))).thenReturn(mockStartUpMetric);
         emitToGraphiteLogbackAppender = new EmitToGraphiteLogbackAppender(
                 mockMetricPublishing, mockMetricObjects, mockFactory);
         emitToGraphiteLogbackAppender.setHost(HOST);
+        emitToGraphiteLogbackAppender.setSubsystem(SUBSYSTEM);
         emitToGraphiteLogbackAppender.setPort(PORT);
         emitToGraphiteLogbackAppender.setPollintervalseconds(POLL_INTERVAL_SECONDS);
         emitToGraphiteLogbackAppender.setQueuesize(QUEUE_SIZE);
@@ -111,7 +118,6 @@ public class EmitToGraphiteLogbackAppenderTest {
     @After
     public void tearDown() {
         ERRORS_COUNTERS.clear();
-        verify(mockFactory).createStartUpMetric(any(MetricObjects.class), any(Timer.class));
         verifyNoMoreInteractions(mockFactory, mockCounter, mockMetricObjects, mockMetricPublishing, mockLoggingEvent,
                 mockStartUpMetric, mockTimer);
     }
@@ -127,11 +133,24 @@ public class EmitToGraphiteLogbackAppenderTest {
                 anyString(), anyString(), anyString(), anyString())).thenReturn(mockCounter);
 
         final Counter counter = factory.createCounter(
-                mockMetricObjects, APPLICATION, FULLY_QUALIFIED_CLASS_NAME, COUNTER_NAME);
+                mockMetricObjects, SUBSYSTEM, START_UP_METRIC_FULLY_QUALIFIED_CLASS_NAME, S_LINE_NUMBER, COUNTER_NAME);
 
         assertSame(mockCounter, counter);
-        verify(mockMetricObjects).createAndRegisterResettingCounter(
-                SUBSYSTEM, APPLICATION, FULLY_QUALIFIED_CLASS_NAME, COUNTER_NAME);
+        verify(mockMetricObjects).createAndRegisterResettingCounter(ERRORS_SUBSYSTEM,
+                SUBSYSTEM + '-' + START_UP_METRIC_FULLY_QUALIFIED_CLASS_NAME, S_LINE_NUMBER, COUNTER_NAME);
+    }
+
+    @Test
+    public void testFactoryCreateStartUpMetric() {
+        when(mockMetricObjects.createAndRegisterResettingCounter(
+                anyString(), anyString(), anyString(), anyString())).thenReturn(mockCounter);
+
+        final StartUpMetric startUpMetric = factory.createStartUpMetric(mockMetricObjects, SUBSYSTEM, mockTimer);
+
+        assertNotNull(startUpMetric);
+        verify(mockMetricObjects).createAndRegisterResettingCounter(ERRORS_SUBSYSTEM,
+                SUBSYSTEM + '-' + START_UP_METRIC_FULLY_QUALIFIED_CLASS_NAME,
+                LINE_NUMBER_OF_EMIT_METHOD_IN_START_UP_METRIC_CLASS, COUNTER_NAME);
     }
 
     @Test
@@ -158,7 +177,7 @@ public class EmitToGraphiteLogbackAppenderTest {
         when(mockLoggingEvent.getLevel()).thenReturn(ERROR);
         final StackTraceElement[] stackTraceElements = new Exception().getStackTrace();
         when(mockLoggingEvent.getCallerData()).thenReturn(stackTraceElements);
-        when(mockFactory.createCounter(any(MetricObjects.class), anyString(), anyString(), anyString()))
+        when(mockFactory.createCounter(any(MetricObjects.class), anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(mockCounter);
 
         emitToGraphiteLogbackAppender.append(mockLoggingEvent);
@@ -166,43 +185,67 @@ public class EmitToGraphiteLogbackAppenderTest {
         verify(mockLoggingEvent).getLevel();
         verify(mockLoggingEvent).getCallerData();
         final String lineNumber = Integer.toString(stackTraceElements[0].getLineNumber());
-        verify(mockFactory).createCounter(mockMetricObjects, FULLY_QUALIFIED_CLASS_NAME, lineNumber, COUNTER_NAME);
+        verify(mockFactory).createCounter(
+                mockMetricObjects, SUBSYSTEM, TEST_CLASS_NAME, lineNumber, COUNTER_NAME);
         verify(mockCounter).increment();
     }
 
     @Test
     public void testStart() {
-        when(mockFactory.createCounter(any(MetricObjects.class), anyString(), anyString(), anyString()))
-                .thenReturn(mockCounter);
+        commonWhensForStart();
 
         emitToGraphiteLogbackAppender.start();
 
         assertTrue(emitToGraphiteLogbackAppender.isStarted());
+        commonVerifiesForStart();
+    }
+
+    @Test
+    public void testStopStartUpMetricIsNotNull() {
+        commonWhensForStart();
+
+        emitToGraphiteLogbackAppender.start();
+        emitToGraphiteLogbackAppender.stop();
+
+        assertFalse(emitToGraphiteLogbackAppender.isStarted());
+        commonVerifiesForStart();
+        verify(mockStartUpMetric).stop();
+        verify(mockMetricPublishing).stop();
+    }
+
+    private void commonWhensForStart() {
+        when(mockFactory.createCounter(any(MetricObjects.class), anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(mockCounter);
+        when(mockFactory.createStartUpMetric(any(MetricObjects.class), anyString(), any(Timer.class)))
+                .thenReturn(mockStartUpMetric);
+    }
+
+    private void commonVerifiesForStart() {
         verify(mockMetricPublishing).start(GRAPHITE_CONFIG);
+        verify(mockFactory).createStartUpMetric(eq(mockMetricObjects), eq(SUBSYSTEM), any(Timer.class));
         verify(mockStartUpMetric).start();
     }
 
     @Test
-    public void testStop() {
+    public void testStopStartUpMetricIsNull() {
         emitToGraphiteLogbackAppender.stop();
 
         assertFalse(emitToGraphiteLogbackAppender.isStarted());
         verify(mockMetricPublishing).stop();
-        verify(mockStartUpMetric).stop();
     }
 
     @Test
     public void testGetCounter() {
         final StackTraceElement stackTraceElement = new StackTraceElement(
-                CLASS.getName(), METHOD_NAME, FILE_NAME, LINE_NUMBER);
-        when(mockFactory.createCounter(any(MetricObjects.class), anyString(), anyString(), anyString()))
+                START_UP_METRIC_CLASS.getName(), METHOD_NAME, FILE_NAME, LINE_NUMBER);
+        when(mockFactory.createCounter(any(MetricObjects.class), anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(mockCounter);
 
         final Counter counter1 = emitToGraphiteLogbackAppender.getCounter(Level.ERROR, stackTraceElement);
         final Counter counter2 = emitToGraphiteLogbackAppender.getCounter(Level.ERROR, stackTraceElement);
 
         assertSame(counter1, counter2);
-        verify(mockFactory).createCounter(
-                mockMetricObjects, FULLY_QUALIFIED_CLASS_NAME, Integer.toString(LINE_NUMBER), Level.ERROR.toString());
+        verify(mockFactory).createCounter(mockMetricObjects, SUBSYSTEM, START_UP_METRIC_FULLY_QUALIFIED_CLASS_NAME,
+                Integer.toString(LINE_NUMBER), Level.ERROR.toString());
     }
  }

--- a/src/test/java/com/expedia/www/haystack/metrics/appenders/logback/StartUpMetricTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/appenders/logback/StartUpMetricTest.java
@@ -16,7 +16,6 @@
 
 package com.expedia.www.haystack.metrics.appenders.logback;
 
-import ch.qos.logback.classic.Level;
 import com.expedia.www.haystack.metrics.MetricObjects;
 import com.netflix.servo.monitor.Counter;
 import org.junit.After;
@@ -27,6 +26,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Random;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -39,12 +39,14 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StartUpMetricTest {
+    static final String LINE_NUMBER_OF_EMIT_METHOD_IN_START_UP_METRIC_CLASS = "63";
+    private static final Random RANDOM = new Random();
+    private static final String SUBSYSTEM = RANDOM.nextLong() + "SUBSYSTEM";
     private static final String FULLY_QUALIFIED_CLASS_NAME = EmitToGraphiteLogbackAppender.changePeriodsToDashes(
             StartUpMetric.class.getName());
-    private static final String LINE_NUMBER_OF_EMIT_METHOD_IN_START_UP_METRIC_CLASS = "61";
 
     @Mock
-    private EmitToGraphiteLogbackAppender.Factory mockFactory;
+    private StartUpMetric.Factory mockFactory;
 
     @Mock
     private Counter mockCounter;
@@ -59,15 +61,14 @@ public class StartUpMetricTest {
 
     @Before
     public void setUp() {
-        when(mockFactory.createCounter(any(MetricObjects.class), anyString(), anyString(), anyString()))
-                .thenReturn(mockCounter);
-        startUpMetric = new StartUpMetric(mockTimer, mockFactory, mockMetricObjects);
+        when(mockFactory.createCounter(any(MetricObjects.class), anyString(), anyString())).thenReturn(mockCounter);
+        startUpMetric = new StartUpMetric(mockTimer, mockFactory, mockMetricObjects, SUBSYSTEM);
     }
 
     @After
     public void tearDown() {
-        verify(mockFactory).createCounter(mockMetricObjects,
-                FULLY_QUALIFIED_CLASS_NAME, LINE_NUMBER_OF_EMIT_METHOD_IN_START_UP_METRIC_CLASS, Level.ERROR.toString());
+        verify(mockFactory).createCounter(
+                mockMetricObjects, SUBSYSTEM, LINE_NUMBER_OF_EMIT_METHOD_IN_START_UP_METRIC_CLASS);
         verifyNoMoreInteractions(mockFactory, mockCounter, mockTimer, mockMetricObjects);
     }
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -9,6 +9,7 @@
     <appender name="EmitToGraphiteLogbackAppender"
               class="com.expedia.www.haystack.metrics.appenders.logback.EmitToGraphiteLogbackAppender">
         <host>127.0.0.1</host>
+        <subsystem>TestSubsystem</subsystem>
         <port>2003</port>                            <!-- Configurations to default values are not needed, but    -->
         <pollintervalseconds>60</pollintervalseconds><!-- are included in this file for reference when writing    -->
         <queuesize>10</queuesize>                    <!-- configuration files in packages that use this Appender. -->


### PR DESCRIPTION
to facilitate writing dashboards (based on the heartbeat metric)
before any real errors have occurred.