### PR TITLE
Upgrade haystack-metrics to 0.10.0 to pick up the change that counts

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.1.14 / 2018-03-06 Use new haystack-metrics 0.10.0
+This new version of haystack-metrics counts that number of times that the metrics polling thread was started
+with a static variable instead of an instance variable.
+
 ## 0.1.13 / 2018-03-05 Use new haystack-metrics 0.8.0
 This new version of haystack-metrics counts that number of times that the metrics polling thread was started, so that it
 can avoid shutting down that thread prematurely. This change was necessitated by the behavior of log4j2 when starting

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-logback-metrics-appender</artifactId>
-    <version>0.1.13-SNAPSHOT</version>
+    <version>0.1.14-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
@@ -56,7 +56,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
-        <haystack-metrics-version>0.8.0</haystack-metrics-version>
+        <haystack-metrics-version>0.10.0</haystack-metrics-version>
         <java.version>1.8</java.version>
         <jacoco-maven-plugin-version>0.7.9</jacoco-maven-plugin-version>
         <jacoco-percentage>1.0</jacoco-percentage>


### PR DESCRIPTION
calls to the polling thread start() method with a static counter.